### PR TITLE
Fix validateCache:false with empty cache

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -93,7 +93,7 @@ GitHubCache.prototype.getCache = function(cache_id, callback) {
   self.cachedb.get(cache_id + self.separator + 'tag', function(err, tag) {
     debug('getCache id: %s, tag: %s', (cache_id + self.separator + 'tag'), tag)
     if (err && err.status == '404') {
-      return callback(null, false, false)
+      return callback(null, false, undefined)
     }
     if (err) {
       debug('getCache error1: %j', err)
@@ -102,7 +102,7 @@ GitHubCache.prototype.getCache = function(cache_id, callback) {
     self.cachedb.get(cache_id + self.separator + 'data', function(err, data) {
       debug('getCache id: %s, data: %j', (cache_id + self.separator + 'data'), data)
       if (err && err.status == '404') {
-        return callback(null, false, false)
+        return callback(null, false, undefined)
       }
       if (err) {
         debug('getCache error1: %j', err)

--- a/test.js
+++ b/test.js
@@ -91,6 +91,7 @@ test('do not validate cache', function(t) {
 
   github.user.getFollowingFromUser({
     user: "ekristen",
+    validateCache: false
   }, function(err, data1) {
     t.ok(!err)
     t.equal(typeof data1.meta, 'object')


### PR DESCRIPTION
Fix the method `getCache` to pass `undefined` instead of `false` to callback's `cached_data` argument. This fixes a bug where API calls made with `validateCache:false` were always returning `false` instead of object/array when the cache was empty.

See also [cache.js#L53](https://github.com/ekristen/node-github-cache/blob/eecd64b86c99612226e90ba103465826b67a900c/cache.js#L53) where the module checks for cached data by comparing against `undefined`.

@ekristen could you please review?
