### PR TITLE
Only require level if not providing you're own cachedb

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,6 +1,5 @@
 var crypto    = require('crypto');
 var GitHubApi = require('github');
-var leveldb   = require('level');
 var lodash    = require('lodash');
 var util      = require('util');
 var debug     = require('debug')('github-cache');
@@ -81,6 +80,8 @@ var GitHubCache = module.exports = function(global_options) {
   if (typeof(this.config.cachedb) == 'object' && typeof(this.config.cachedb.put) == 'function') {
     this.cachedb = this.config.cachedb;
   } else {
+    var leveldb = require('level');
+
     this.cachedb = leveldb(this.config.cachedb || './cachedb');
   }
 };


### PR DESCRIPTION
I _really_ love this module, but it has one issue that is causing me grief:
I'm using this module in an nwjs app, and because leveldb is running node-gyp as part of it's install process, it causes a bindings mismatch when this file is loaded. (This is a common issue with nwjs projects, but they have nw-gyp as a replacement; but because this error is because of a dependency of a dependency, actually using it in this case is not really feasible).

However, I have no problem providing my own cachedb object, and moving the require into this if statement makes it so that I have a way to use the module without worrying about level's bindings.

Would you consider merging this in?

Thanks!
