### PR TITLE
add support for node-github 13.x.x

### DIFF
--- a/test.js
+++ b/test.js
@@ -155,3 +155,28 @@ test('custom cache instance using MemDB', function (t) {
     })
   })
 })
+
+test('promise support', function (t) {
+  var dbpath = './testcachedb' + new Date().getTime()
+  var dburi = 'level://localhost/' + dbpath
+
+  var github = new GitHubCache(githubapi, {
+    cachedb: {
+      uri: dburi
+    }
+  })
+
+  var promise = github.users.getFollowingForUser({
+    username: 'ekristen'
+  }, function (err, data) {
+    t.equal(promise, undefined, 'should not return promise when callback is provided')
+    
+    promise = github.users.getFollowingForUser({
+      username: 'ekristen'
+    }).then(function (data) {
+      rimraf(dbpath, t.end.bind(null))
+    })
+
+    t.ok(promise instanceof Promise, 'should return promise when callback is not provided')
+  })
+})


### PR DESCRIPTION
:warning: node-github-cache won't function with node-github until https://github.com/octokit/node-github/commit/a0c65a2802a62c042a1cb6af2c6d0265ed8bdea2 is released on npm.  As a workaround, the tests can be run by doing the following:

```shell
npm install
npm install https://github.com/octokit/node-github#v13.1.0
export GHTOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx && node test.js
```